### PR TITLE
chore: Update UniFFI to 0.26 and apply rustfmt formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,9 +849,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "goblin"
-version = "0.6.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
 dependencies = [
  "log",
  "plain",
@@ -2072,18 +2072,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2274,6 +2274,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "snow"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2380,6 +2386,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2665,10 +2682,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
-name = "uniffi"
-version = "0.25.3"
+name = "unicode-linebreak"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21345172d31092fd48c47fd56c53d4ae9e41c4b1f559fb8c38c1ab1685fd919f"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "uniffi"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
 dependencies = [
  "anyhow",
  "uniffi_core",
@@ -2677,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd992f2929a053829d5875af1eff2ee3d7a7001cb3b9a46cc7895f2caede6940"
+checksum = "ab31006ab9c9c6870739f0e74235729d1478d82e73571b8f53c25aa176d67535"
 dependencies = [
  "anyhow",
  "askama",
@@ -2692,6 +2721,7 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
+ "textwrap",
  "toml",
  "uniffi_meta",
  "uniffi_testing",
@@ -2700,9 +2730,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001964dd3682d600084b3aaf75acf9c3426699bc27b65e96bb32d175a31c74e9"
+checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
 dependencies = [
  "anyhow",
  "camino",
@@ -2711,9 +2741,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55137c122f712d9330fd985d66fa61bdc381752e89c35708c13ce63049a3002c"
+checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
 dependencies = [
  "quote",
  "syn",
@@ -2721,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6121a127a3af1665cd90d12dd2b3683c2643c5103281d0fed5838324ca1fad5b"
+checksum = "8d6e8db3f4e558faf0e25ac4b5bd775567973a4e18809f1123e74de52a853692"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2737,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cf7a58f101fcedafa5b77ea037999b88748607f0ef3a33eaa0efc5392e92e4"
+checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
 dependencies = [
  "bincode",
  "camino",
@@ -2756,9 +2786,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dc8573a7b1ac4b71643d6da34888273ebfc03440c525121f1b3634ad3417a2"
+checksum = "3f64a99e905671738d9d293f9cce58708ce1af8e13ea29f9d6b6925114fc2e85"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2768,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118448debffcb676ddbe8c5305fb933ab7e0123753e659a71dc4a693f8d9f23c"
+checksum = "cdca5719a22edf34c8239cc6ac9e3906d7ebc2a3e8a5e6ece4c3dffc312a4251"
 dependencies = [
  "anyhow",
  "camino",
@@ -2781,11 +2811,12 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889edb7109c6078abe0e53e9b4070cf74a6b3468d141bdf5ef1bd4d1dc24a1c3"
+checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
 dependencies = [
  "anyhow",
+ "textwrap",
  "uniffi_meta",
  "uniffi_testing",
  "weedle2",
@@ -2950,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "weedle2"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,15 +39,15 @@ region = { version = "3", optional = true }
 pubky = { version = "0.6.0-rc.6", optional = true }
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", features = ["rt"], optional = true }
-uniffi = { version = "0.25", optional = true }
+uniffi = { version = "0.26", optional = true }
 
 [build-dependencies]
-uniffi_build = "0.25"
+uniffi_build = "0.26"
 
 [dev-dependencies]
 rand_core = "0.6"
 tokio = { version = "1", features = ["full"] }
-uniffi_bindgen = "0.25"
+uniffi_bindgen = "0.26"
 loom = "0.7"
 sha2 = "0.10"
 rand = "0.8"

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -263,7 +263,10 @@ impl RateLimiter {
     ///
     /// Note: Recovers gracefully from lock poisoning rather than panicking.
     pub fn tracked_ip_count(&self) -> usize {
-        self.trackers.lock().unwrap_or_else(|e| e.into_inner()).len()
+        self.trackers
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .len()
     }
 
     /// Get remaining attempts for an IP within the current window.
@@ -291,7 +294,10 @@ impl RateLimiter {
     ///
     /// Note: Recovers gracefully from lock poisoning rather than panicking.
     pub fn clear(&self) {
-        self.trackers.lock().unwrap_or_else(|e| e.into_inner()).clear();
+        self.trackers
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
     }
 
     /// Run cleanup of expired entries.

--- a/src/session_manager.rs
+++ b/src/session_manager.rs
@@ -187,10 +187,7 @@ impl<R: RingKeyProvider> ThreadSafeSessionManager<R> {
     where
         F: FnOnce(&NoiseLink) -> T,
     {
-        let manager = self
-            .inner
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let manager = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         manager.get_session(session_id).map(f)
     }
 
@@ -201,10 +198,7 @@ impl<R: RingKeyProvider> ThreadSafeSessionManager<R> {
     where
         F: FnOnce(&mut NoiseLink) -> T,
     {
-        let mut manager = self
-            .inner
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut manager = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         manager.get_session_mut(session_id).map(f)
     }
 
@@ -216,10 +210,7 @@ impl<R: RingKeyProvider> ThreadSafeSessionManager<R> {
         session_id: &SessionId,
         plaintext: &[u8],
     ) -> Result<Vec<u8>, crate::errors::NoiseError> {
-        let mut manager = self
-            .inner
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut manager = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         manager
             .get_session_mut(session_id)
             .ok_or_else(|| crate::errors::NoiseError::Other("Session not found".to_string()))?
@@ -234,10 +225,7 @@ impl<R: RingKeyProvider> ThreadSafeSessionManager<R> {
         session_id: &SessionId,
         ciphertext: &[u8],
     ) -> Result<Vec<u8>, crate::errors::NoiseError> {
-        let mut manager = self
-            .inner
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut manager = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         manager
             .get_session_mut(session_id)
             .ok_or_else(|| crate::errors::NoiseError::Other("Session not found".to_string()))?


### PR DESCRIPTION
## Summary

This PR updates UniFFI dependencies to version 0.26 and applies rustfmt formatting to maintain consistency.

## Changes

- **UniFFI Update**: Updated `uniffi`, `uniffi_build`, and `uniffi_bindgen` from 0.25 to 0.26
- **Formatting**: Applied rustfmt formatting to `rate_limiter.rs` and `session_manager.rs`
- **Dependencies**: Updated `Cargo.lock` with new dependency versions

## Motivation

These changes ensure compatibility with paykit-rs which uses UniFFI 0.26 and maintains consistent code formatting across the codebase.

## Testing

- ✅ All tests pass
- ✅ Cargo build succeeds
- ✅ No breaking changes to public API